### PR TITLE
Adds ability to use <% cache %><% end_cache %> to template parser

### DIFF
--- a/_config/config.yml
+++ b/_config/config.yml
@@ -6,6 +6,10 @@ Director:
     'cache-include//$Action': 'CacheIncludeController'
 
 Injector:
+  SSTemplateParser:
+      properties:
+        closedBlocks:
+          cache: "CacheIncludeExtension::cacheTemplate"
   CacheInclude:
     class: Heyday\CacheInclude\CacheInclude
     constructor:


### PR DESCRIPTION
Using the new SilverStripe template parser extension functionality this
change allows the use of a new template syntax to cache blocks of
template content

Example:

<% cache 'ConfigName' %>

Some content

<% end_cache %>
