### PR TITLE
FIX CMSPreview 500 error

### DIFF
--- a/main.php
+++ b/main.php
@@ -2,25 +2,31 @@
 
 require_once __DIR__.'/../framework/core/Core.php';
 
-$request = new SS_HTTPRequest(
-    $_SERVER['REQUEST_METHOD'],
-    isset($_GET['url']) ? $_GET['url'] : '', 
-    $_GET
-);
+\Versioned::choose_site_stage();
 
-$headers = Director::extract_request_headers($_SERVER);
+// Only skip framework/main.php if live stage
+if (\Versioned::current_stage() == \Versioned::get_live_stage()) {
 
-foreach ($headers as $header => $value) {
-    $request->addHeader($header, $value);
+    $request = new SS_HTTPRequest(
+        $_SERVER['REQUEST_METHOD'],
+        isset($_GET['url']) ? $_GET['url'] : '',
+        $_GET
+    );
+
+    $headers = Director::extract_request_headers($_SERVER);
+
+    foreach ($headers as $header => $value) {
+        $request->addHeader($header, $value);
+    }
+
+    $container = Injector::inst();
+
+    $session = $container->create('Session', array());
+    if (Session::request_contains_session_id()) {
+        $session->inst_start();
+    }
+
+    $container->get('RequestProcessor')->preRequest($request, $session, DataModel::inst());
 }
-
-$container = Injector::inst();
-
-$session = $container->create('Session', array());
-if (Session::request_contains_session_id()) {
-    $session->inst_start();
-}
-
-$container->get('RequestProcessor')->preRequest($request, $session, DataModel::inst());
 
 require_once __DIR__.'/../framework/main.php';


### PR DESCRIPTION
A bit of a crude fix for https://github.com/heyday/silverstripe-cacheinclude/issues/23

CMS Preview of Live mode doesn't require a DB connection to check if the user can view the stage so is still allowed to run
