### PR TITLE
DOCS: add required Global config to RequestCache example

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,16 @@ Injector:
       filters:
         - '%$RequestCache'
 
+  CacheIncludeConfig:
+    class: Heyday\CacheInclude\Configs\ArrayConfig
+    properties:
+      Config:
+        Global:
+          context: full
+          contains:
+            - MyDataObject
+          expires: +1 hour
+
   RequestCache:
     class: Heyday\CacheInclude\RequestCache
     constructor:


### PR DESCRIPTION
Got caught up by #24 so have updated the example to include the required Global config block