### PR TITLE
Fix issue where Request object could be wrong in full request caching

### DIFF
--- a/src/RequestCache.php
+++ b/src/RequestCache.php
@@ -167,7 +167,7 @@ class RequestCache implements RequestFilter
     public function preRequest(SS_HTTPRequest $request, Session $session, DataModel $model)
     {
         if ($this->allowFetch($request)) {
-            \Versioned::choose_site_stage();
+            \Versioned::choose_site_stage($request);
             if ($request->getURL() == '') {
                 $request = clone $request;
                 $request->setUrl('home');


### PR DESCRIPTION
Ensure that the `Request` which is used in the RequestCache `preRequest` call is used to determine the appropriate versioned stage instead of relying on the default fallback within that class.

This presented itself in SS 3.7.0 using the default `main.php`