### PR TITLE
BUG Fix count(null) warning

### DIFF
--- a/src/SilverStripe/RequestCacheMiddleware.php
+++ b/src/SilverStripe/RequestCacheMiddleware.php
@@ -59,7 +59,7 @@ class RequestCacheMiddleware implements HTTPMiddleware
     /**
      * @var array
      */
-    protected $tokens;
+    protected $tokens = [];
 
     /**
      * @var ExpressionLanguage


### PR DESCRIPTION
when you do count() on an uninitialised variable you get a warning. See:

```php
    /**
     * @return bool
     */
    protected function hasTokens()
    {
        return count($this->tokens) > 0;
    }
```