### PR TITLE
ENH loosen yaml constraints to allow v4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     ],
     "require": {
         "silverstripe/framework": "^4.2",
-        "symfony/yaml": "^3.2",
+        "symfony/yaml": "^3.2 || ^4",
         "symfony/expression-language": "^3.2"
     },
     "require-dev": {


### PR DESCRIPTION
Fixes install issues on newer SS4 installs which use yaml 4