### PR TITLE
__serialize must return array 8.1

### DIFF
--- a/src/ExpressionLanguage.php
+++ b/src/ExpressionLanguage.php
@@ -43,11 +43,11 @@ class ExpressionLanguage extends SymfonyExpressionLanguage
     }
 
     /**
-     * @return null
+     * @return array
      */
     public function __serialize()
     {
-        return null;
+        return [];
     }
 
     /**


### PR DESCRIPTION
In  php 8.1 return type __serialize must always be an array, so you can't return null.